### PR TITLE
Ignore EquipmentChangeMessage

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -3,6 +3,7 @@
     const IGNORED_TYPES = [
         "MapShouldUpdateMessage",
         "PlanCompletedMessage",
+        "EquipmentChangeMessage",
     ];
     const ALWAYS_SHOWN_TYPES = [
         "DifficultyRollFailureMessage",


### PR DESCRIPTION
Some actions can generate an EquipmentChangeMessage, which seems to trigger API calls to `/myself` and to `/outfit`. It gets generated (presumably) when the player character is given an item which is instantly equipped, like "An Infant Curator, Provisionally Known as Mr Transport" (confirmed) or a Destiny (assumed).

This patch adds this type of message to the list of ignored messages.