### PR TITLE
Add browser_specific_settings to manifest.json 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.mp3
 .idea
-*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.mp3
 .idea
+*.zip

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,18 @@
 {
   "name": "FL Quality Lantern",
   "description": "Reveal hidden Qualities in Fallen London storylets.",
-  "version": "1.2.4",
+  "version": "1.2.4", 
   "manifest_version": 2,
   "permissions": [],
+  
+  "browser_specific_settings": {
+    "gecko": {
+      "strict_min_version": "102.0"
+  },
+    "gecko_android": {
+      "strict_min_version": "120.0"
+    }
+  },
   "content_scripts": [
     {
       "matches": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,18 @@
 {
-  "name": "FL Quality Lantern",
+  "name": "Fallen London Quality Lantern",
   "description": "Reveal hidden Qualities in Fallen London storylets.",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "manifest_version": 2,
   "permissions": [],
+  
+  "browser_specific_settings": {
+    "gecko": {
+      "strict_min_version": "102.0"
+  },
+    "gecko_android": {
+      "strict_min_version": "120.0"
+    }
+  },
   "content_scripts": [
     {
       "matches": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,18 +1,9 @@
 {
-  "name": "Fallen London Quality Lantern",
+  "name": "FL Quality Lantern",
   "description": "Reveal hidden Qualities in Fallen London storylets.",
-  "version": "1.2.5",
+  "version": "1.2.4",
   "manifest_version": 2,
   "permissions": [],
-  
-  "browser_specific_settings": {
-    "gecko": {
-      "strict_min_version": "102.0"
-  },
-    "gecko_android": {
-      "strict_min_version": "120.0"
-    }
-  },
   "content_scripts": [
     {
       "matches": [


### PR DESCRIPTION
Added a browser_specific_settings section to manifest.json which necessary for [addons.mozilla.org](https://addons.mozilla.org) to allow installation of the extension on Firefox Mobile. The version targeted (120.0) ended Mozilla’s restriction to only a few select extensions.