### PR TITLE
Show hidden qualities after starting an agent plot

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -55,6 +55,7 @@
         }
 
         if (!(targetUrl.includes("/storylet")
+            || targetUrl.includes("/agents/begin")
             || targetUrl.includes("/agents/branch")
             || targetUrl.includes("/choosebranch"))) {
             return;
@@ -64,7 +65,9 @@
 
         let data = JSON.parse(response.target.responseText);
 
-        if (targetUrl.endsWith("/choosebranch") || targetUrl.endsWith("/agents/branch")) {
+        if (targetUrl.endsWith("/choosebranch")
+            || targetUrl.endsWith("/agents/begin")
+            || targetUrl.endsWith("/agents/branch")) {
             if ("messages" in data) {
                 for (const message of data.messages) {
                     if (IGNORED_TYPES.includes(message["type"])) {


### PR DESCRIPTION
This PR adds `/agents/begin` to the list of routes handled by the response parser in `inject.js`, in order to reveal the qualities returned when an agent plot is started.

Tested the fix manually in Firefox (by loading the modified unpacked extension).

### Screenshots

Before:
<img width="1550" height="668" src="https://github.com/user-attachments/assets/232ee904-839e-4317-a8b2-3d46dbe601f6" />

After:
<img width="1543" height="779" src="https://github.com/user-attachments/assets/61668931-2f10-4240-9d41-51f35b49420d" />
